### PR TITLE
Format About Page - Proposed fix Cybros/Cybros-Web-Application#30

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,6 +2,14 @@ body{
     background-color: #EDEDED;
     height: 100%;
 }
+
+.inner {
+    max-width:1170px;
+    position: relative;
+    padding: 0 40px;
+    margin: 0 auto
+}
+
 /*Navbar*/
 .topNavbar{
     padding-bottom:30px;

--- a/views/about.hbs
+++ b/views/about.hbs
@@ -1,6 +1,6 @@
 {{> header}}
 
-        <div style="padding-top:97px;">
+        <div class="inner" style="padding-top:97px;">
             <h3 class="text-center filler-heading">About us</h3>
             <p>
                 The Cybros Computer Club at The LNMIIT exists to help you be a better programmer. C3 encourages students to "keep coding, keep contributing, and keep developing" by providing workshops, classes, and competitions. We're all in this together to solve problems and code all the things. Join our club to take coding a step further and meet people who love the same things you do.
@@ -18,4 +18,4 @@ The club today is an active platform for students to display and develop their p
             </p>
         </div>
 
-{{> footer}}
+{{> footer hideAboutInFooter=42}}

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -1,9 +1,12 @@
             <div class="container-fluid footer">
                 <div class="row">
                     <div class="col-sm-6">
-                        <h4>About Us</h4>
-                        <p>Cybros Computer Club, The LNMIIT, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat
-                        </p></div>
+                        {{#if hideAboutInFooter}}
+                        {{else}}
+                            <h4>About Us</h4>
+                            <p>Cybros Computer Club, The LNMIIT, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</p>
+                        {{/if}}
+                    </div>
 
                     <div class="col-sm-2 col-md-offset-1">
                         <h4>Shortcut</h4>


### PR DESCRIPTION
I added a context for the partial footer call to hide the "about" section in the footer on the about page.

Also I added the class ".inner" to the whole about container to set a max-width.

Since I did not know what you mean by "links to coordinator's account" I did not include that one.