### PR TITLE
Fixed issue with width of E-mail input below max-width 1000px

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -341,6 +341,7 @@ a{
         overflow: auto;
         position: absolute;
     }
+    .login-box input[type="email"],
     .login-box input[type="text"],
     .login-box input[type="password"] {
         width: 100%;


### PR DESCRIPTION
The input box for e-mail in sign-up was smaller than the other input boxes for screens with width below 1000px. Fixed it so that they have the same width.